### PR TITLE
Add support for missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ with a JSON payload of the form:
     // List of algorithms used to filter the data
     // - optional, defaults to no filters
     "filters": [{"id": "shuffle", "element_size": 4}],
+
+    // Missing data description
+    // - optional, defaults to no missing data
+    // - exactly one of the keys below should be specified
+    // - the values should match the data type (dtype)
+    "missing": {
+        "missing_value": 42,
+        "missing_values": [42, -42],
+        "valid_min": 42,
+        "valid_max": 42,
+        "valid_range": [-42, 42],
+    }
 }
 ```
 

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -38,8 +38,21 @@ def get_args() -> argparse.Namespace:
     parser.add_argument("--selection", type=str)
     parser.add_argument("--compression", type=str)
     parser.add_argument("--shuffle", action=argparse.BooleanOptionalAction)
+    missing = parser.add_mutually_exclusive_group()
+    missing.add_argument("--missing-value", type=str)
+    missing.add_argument("--missing-values", type=str)
+    missing.add_argument("--valid-min", type=str)
+    missing.add_argument("--valid-max", type=str)
+    missing.add_argument("--valid-range", type=str)
     parser.add_argument("--verbose", action=argparse.BooleanOptionalAction)
     return parser.parse_args()
+
+
+def parse_number(s: str):
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)
 
 
 def build_request_data(args: argparse.Namespace) -> dict:
@@ -65,6 +78,20 @@ def build_request_data(args: argparse.Namespace) -> dict:
         filters.append({"id": "shuffle", "element_size": element_size})
     if filters:
         request_data["filters"] = filters
+    missing = None
+    if args.missing_value:
+        missing = {"missing_value": parse_number(args.missing_value)}
+    if args.missing_values:
+        missing = {"missing_values": [parse_number(n) for n in args.missing_values.split(",")]}
+    if args.valid_min:
+        missing = {"valid_min": parse_number(args.valid_min)}
+    if args.valid_max:
+        missing = {"valid_max": parse_number(args.valid_max)}
+    if args.valid_range:
+        min, max = args.valid_range.split(",")
+        missing = {"valid_range": [parse_number(min), parse_number(max)]}
+    if missing:
+        request_data["missing"] = missing
     return {k: v for k, v in request_data.items() if v is not None}
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,4 +38,5 @@ pub mod server;
 #[cfg(test)]
 pub mod test_utils;
 pub mod tracing;
+pub mod types;
 pub mod validated_json;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -2,6 +2,7 @@
 
 use crate::error::ActiveStorageError;
 use crate::models;
+use crate::types::dvalue::TryFromDValue;
 
 use axum::body::Bytes;
 
@@ -12,9 +13,12 @@ pub trait Element:
     + PartialOrd
     + num_traits::FromPrimitive
     + num_traits::Zero
+    + std::convert::From<u16>
     + std::fmt::Debug
+    + std::iter::Sum
     + std::ops::Add<Output = Self>
     + std::ops::Div<Output = Self>
+    + TryFromDValue
     + zerocopy::AsBytes
     + zerocopy::FromBytes
 {
@@ -28,9 +32,12 @@ impl<T> Element for T where
         + num_traits::FromPrimitive
         + num_traits::One
         + num_traits::Zero
+        + std::convert::From<u16>
         + std::fmt::Debug
+        + std::iter::Sum
         + std::ops::Add<Output = Self>
         + std::ops::Div<Output = Self>
+        + TryFromDValue
         + zerocopy::AsBytes
         + zerocopy::FromBytes
 {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -100,7 +100,7 @@ impl NumOperation for Max {
                 .fold((None, 0), |(a, count), b| {
                     let max = match (a, b) {
                         (None, b) => Some(b), //FIXME: if b.is_finite() { Some(b) } else { None },
-                        (a, b) => Some(std::cmp::max_by(a.unwrap(), b, |x, y| {
+                        (Some(a), b) => Some(std::cmp::max_by(a, b, |x, y| {
                             x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Greater)
                         })),
                     };
@@ -153,7 +153,7 @@ impl NumOperation for Min {
                 .fold((None, 0), |(a, count), b| {
                     let min = match (a, b) {
                         (None, b) => Some(b), //FIXME: if b.is_finite() { Some(b) } else { None },
-                        (a, b) => Some(std::cmp::min_by(a.unwrap(), b, |x, y| {
+                        (Some(a), b) => Some(std::cmp::min_by(a, b, |x, y| {
                             x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Less)
                         })),
                     };

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::models::*;
+use crate::types::Missing;
 
 use url::Url;
 
@@ -16,6 +17,7 @@ pub(crate) fn get_test_request_data() -> RequestData {
         selection: None,
         compression: None,
         filters: None,
+        missing: None,
     }
 }
 
@@ -33,5 +35,6 @@ pub(crate) fn get_test_request_data_optional() -> RequestData {
         selection: Some(vec![Slice::new(1, 2, 3), Slice::new(4, 5, 6)]),
         compression: Some(Compression::Gzip),
         filters: Some(vec![Filter::Shuffle { element_size: 4 }]),
+        missing: Some(Missing::MissingValue(42.into())),
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,6 @@
+pub mod dvalue;
+pub mod missing;
+
+// Re-export types for convenience.
+pub use crate::types::dvalue::DValue;
+pub use crate::types::missing::Missing;

--- a/src/types/dvalue.rs
+++ b/src/types/dvalue.rs
@@ -1,0 +1,200 @@
+use crate::error::ActiveStorageError;
+
+/// A value of any DType.
+/// This is an alias of the Number type from serde_json, which is an enum that can represent
+/// integers and floating point numbers.
+/// The number type is an enum over i64, u64 and f64, with the additional constraint that floating
+/// point numbers must be finite (not positive or negative infinity or NaN).
+pub type DValue = serde_json::Number;
+
+/// Try to convert a DValue to an i64.
+fn as_i64(value: &DValue) -> Result<i64, ActiveStorageError> {
+    value
+        .as_i64()
+        .ok_or(ActiveStorageError::IncompatibleMissing(value.clone()))
+}
+
+/// Try to convert a DValue to a u64.
+fn as_u64(value: &DValue) -> Result<u64, ActiveStorageError> {
+    value
+        .as_u64()
+        .ok_or(ActiveStorageError::IncompatibleMissing(value.clone()))
+}
+
+/// Try to convert a DValue to an f64.
+fn as_f64(value: &DValue) -> Result<f64, ActiveStorageError> {
+    value
+        .as_f64()
+        .ok_or(ActiveStorageError::IncompatibleMissing(value.clone()))
+}
+
+/// Attempt to convert from a [DValue](crate::types::DValue) to specific numeric type.
+// This trait exists because we can't implement TryFrom<DValue> for numeric types because the trait
+// and type are in external crates.
+pub trait TryFromDValue: Sized {
+    /// Try to convert from a [DValue](crate::types::DValue) to a numeric type.
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError>;
+}
+
+// Implement the TryFromDValue trait for all supported numeric data types.
+
+impl TryFromDValue for i32 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        Self::try_from(as_i64(&value)?).map_err(|_| ActiveStorageError::IncompatibleMissing(value))
+    }
+}
+
+impl TryFromDValue for i64 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        as_i64(&value)
+    }
+}
+
+impl TryFromDValue for u32 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        Self::try_from(as_u64(&value)?).map_err(|_| ActiveStorageError::IncompatibleMissing(value))
+    }
+}
+
+impl TryFromDValue for u64 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        as_u64(&value)
+    }
+}
+
+impl TryFromDValue for f32 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        // If the number is too large to be represented as an f32 this cast returns infinity.
+        let float = as_f64(&value)? as f32;
+        if float.is_finite() {
+            Ok(float)
+        } else {
+            Err(ActiveStorageError::IncompatibleMissing(value))
+        }
+    }
+}
+
+impl TryFromDValue for f64 {
+    fn try_from_dvalue(value: DValue) -> Result<Self, ActiveStorageError> {
+        as_f64(&value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_traits::Float;
+
+    use super::*;
+
+    #[test]
+    fn test_dvalue_is_finite() {
+        assert!(DValue::from_f64(f64::infinity()).is_none());
+    }
+
+    #[test]
+    fn test_dvalue_is_not_nan() {
+        assert!(DValue::from_f64(f64::nan()).is_none());
+    }
+
+    #[test]
+    fn test_try_from_dvalue_i32() {
+        let result = i32::try_from_dvalue(42.into()).unwrap();
+        assert_eq!(42, result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(2147483648))")]
+    fn test_try_from_dvalue_i32_too_large() {
+        i32::try_from_dvalue((i32::max_value() as i64 + 1).into()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(-2147483649))")]
+    fn test_try_from_dvalue_i32_too_negative() {
+        i32::try_from_dvalue((i32::min_value() as i64 - 1).into()).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_dvalue_i64() {
+        let result = i64::try_from_dvalue((-42).into()).unwrap();
+        assert_eq!(-42, result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(9223372036854775808))")]
+    fn test_try_from_dvalue_i64_too_large() {
+        i64::try_from_dvalue((i64::max_value() as u64 + 1).into()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(1.0))")]
+    fn test_try_from_dvalue_i64_float() {
+        i64::try_from_dvalue(DValue::from_f64(1.0).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_dvalue_u32() {
+        let result = u32::try_from_dvalue(42.into()).unwrap();
+        assert_eq!(42, result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(4294967296))")]
+    fn test_try_from_dvalue_u32_too_large() {
+        u32::try_from_dvalue((u32::max_value() as u64 + 1).into()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(-1))")]
+    fn test_try_from_dvalue_u32_negative() {
+        u32::try_from_dvalue((-1).into()).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_dvalue_u64() {
+        let result = u64::try_from_dvalue(42.into()).unwrap();
+        assert_eq!(42, result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(-1))")]
+    fn test_try_from_dvalue_u64_negative() {
+        u64::try_from_dvalue((-1).into()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(-1.0))")]
+    fn test_try_from_dvalue_u64_float() {
+        u64::try_from_dvalue(DValue::from_f64(-1.0).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_dvalue_f32() {
+        let result = f32::try_from_dvalue(DValue::from_f64(42.0).unwrap()).unwrap();
+        assert_eq!(42.0, result);
+    }
+
+    #[test]
+    fn test_try_from_dvalue_f32_int() {
+        let result = f32::try_from_dvalue(42_u64.into()).unwrap();
+        assert_eq!(42.0, result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(6.805646932770577e38))")]
+    fn test_try_from_dvalue_f32_too_large() {
+        f32::try_from_dvalue(DValue::from_f64((f32::max_value() as f64) * 2.0).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_dvalue_f64() {
+        let result = f64::try_from_dvalue(DValue::from_f64(-42.0).unwrap()).unwrap();
+        assert_eq!(-42.0, result);
+    }
+
+    #[test]
+    fn test_try_from_dvalue_f64_int() {
+        let result = f64::try_from_dvalue(42_u64.into()).unwrap();
+        assert_eq!(42.0, result);
+    }
+}

--- a/src/types/missing.rs
+++ b/src/types/missing.rs
@@ -1,0 +1,222 @@
+use serde::{Deserialize, Serialize};
+use validator::ValidationError;
+
+use crate::error::ActiveStorageError;
+use crate::models::DType;
+use crate::types::dvalue::TryFromDValue;
+use crate::types::DValue;
+
+/// Missing data
+///
+/// This enum can represent all known descriptions of missing data used in NetCDF4 files.
+/// It is generic over the type of missing data values. We use this in two ways:
+/// 1. T = [DValue](crate::types::DValue), used in the API to represent values of any supported
+///    [DType](crate::models::DType).
+/// 2. T = a primitive numeric type (i32, u64, f32, etc.), used in numeric operations when we know
+///    the DType of the values.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Missing<T> {
+    /// A single missing value
+    MissingValue(T),
+    /// Multple missing values
+    MissingValues(Vec<T>),
+    /// Valid minimum
+    ValidMin(T),
+    /// Valid maxiumum
+    ValidMax(T),
+    /// Valid range
+    ValidRange(T, T),
+}
+
+impl Missing<DValue> {
+    /// Validate a Missing<DValue> object for a given DType.
+    pub fn validate(&self, dtype: DType) -> Result<(), ValidationError> {
+        match dtype {
+            DType::Int32 => Missing::<i32>::validate_dvalue(self),
+            DType::Int64 => Missing::<i64>::validate_dvalue(self),
+            DType::Uint32 => Missing::<u32>::validate_dvalue(self),
+            DType::Uint64 => Missing::<u64>::validate_dvalue(self),
+            DType::Float32 => Missing::<f32>::validate_dvalue(self),
+            DType::Float64 => Missing::<f64>::validate_dvalue(self),
+        }
+    }
+}
+
+impl<T: PartialOrd + Serialize + TryFromDValue> Missing<T> {
+    /// Validate a Missing<DValue> for Missing<T> where T is a supported primitive numeric type.
+    fn validate_dvalue(missing: &Missing<DValue>) -> Result<(), ValidationError> {
+        // Perform a conversion to the primitive based type.
+        let missing_primitive = Self::try_from(missing).map_err(|err| {
+            let mut error = ValidationError::new("Missing data descriptor is invalid");
+            error.add_param("error".into(), &err.to_string());
+            error
+        })?;
+        // Validate min + max for valid ranges.
+        if let Missing::ValidRange(min, max) = missing_primitive {
+            if min >= max {
+                let mut error =
+                    ValidationError::new("Missing data valid range min must be less than max");
+                error.add_param("min".into(), &min);
+                error.add_param("max".into(), &max);
+                return Err(error);
+            };
+        };
+        Ok(())
+    }
+}
+
+// Implement TryFrom<&Missing<DValue>> for Missing<T>.
+// This allows us to convert from a Missing type based on the enum DValue type to a numeric type.
+impl<T: TryFromDValue> TryFrom<&Missing<DValue>> for Missing<T> {
+    type Error = ActiveStorageError;
+
+    fn try_from(missing: &Missing<DValue>) -> Result<Self, Self::Error> {
+        let result = match missing {
+            Missing::MissingValue(value) => {
+                Missing::<T>::MissingValue(T::try_from_dvalue(value.clone())?)
+            }
+            Missing::MissingValues(values) => {
+                // Map to Results, then use ? on the collected Vec to fail if any is Err.
+                let values = values
+                    .iter()
+                    .map(|value| T::try_from_dvalue(value.clone()))
+                    .collect::<Result<Vec<T>, _>>()?;
+                Missing::<T>::MissingValues(values)
+            }
+            Missing::ValidMin(min) => Missing::<T>::ValidMin(T::try_from_dvalue(min.clone())?),
+            Missing::ValidMax(max) => Missing::<T>::ValidMax(T::try_from_dvalue(max.clone())?),
+            Missing::ValidRange(min, max) => Missing::<T>::ValidRange(
+                T::try_from_dvalue(min.clone())?,
+                T::try_from_dvalue(max.clone())?,
+            ),
+        };
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_traits::Float;
+
+    use super::*;
+
+    #[test]
+    fn test_try_from_missing_value() {
+        let result = Missing::<i32>::try_from(&Missing::<DValue>::MissingValue(42.into())).unwrap();
+        assert_eq!(Missing::<i32>::MissingValue(42), result);
+    }
+
+    #[test]
+    fn test_validate_i32() {
+        Missing::<DValue>::MissingValue(42.into())
+            .validate(DType::Int32)
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Incompatible value -1 for missing")]
+    fn test_validate_u32_negative() {
+        Missing::<DValue>::MissingValue((-1).into())
+            .validate(DType::Uint32)
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing data valid range min must be less than max")]
+    fn test_validate_f32_range_min_gt_max() {
+        Missing::<DValue>::ValidRange(
+            DValue::from_f64(42.0).unwrap(),
+            DValue::from_f64(-42.0).unwrap(),
+        )
+        .validate(DType::Float32)
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing data valid range min must be less than max")]
+    fn test_validate_f32_range_min_eq_max() {
+        Missing::<DValue>::ValidRange(
+            DValue::from_f64(42.0).unwrap(),
+            DValue::from_f64(42.0).unwrap(),
+        )
+        .validate(DType::Float32)
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(2147483648))")]
+    fn test_try_from_missing_value_too_large() {
+        Missing::<i32>::try_from(&Missing::<DValue>::MissingValue(
+            (i32::max_value() as i64 + 1).into(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn test_try_from_missing_values() {
+        let result = Missing::<i64>::try_from(&Missing::<DValue>::MissingValues(vec![
+            42.into(),
+            (-1).into(),
+        ]))
+        .unwrap();
+        assert_eq!(Missing::<i64>::MissingValues(vec![42, -1]), result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(9223372036854775808))")]
+    fn test_try_from_missing_values_too_large() {
+        Missing::<i64>::try_from(&Missing::<DValue>::MissingValues(vec![
+            (i64::max_value() as u64 + 1).into(),
+            (-1).into(),
+        ]))
+        .unwrap();
+    }
+
+    #[test]
+    fn test_try_from_valid_min() {
+        let result = Missing::<u32>::try_from(&Missing::<DValue>::ValidMin(42.into())).unwrap();
+        assert_eq!(Missing::<u32>::ValidMin(42), result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(4294967296))")]
+    fn test_try_from_valid_min_too_large() {
+        Missing::<u32>::try_from(&Missing::<DValue>::ValidMin(
+            (u32::max_value() as u64 + 1).into(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn test_try_from_valid_max() {
+        let result = Missing::<u64>::try_from(&Missing::<DValue>::ValidMax(42.into())).unwrap();
+        assert_eq!(Missing::<u64>::ValidMax(42), result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(-1))")]
+    fn test_try_from_valid_max_negative() {
+        Missing::<u64>::try_from(&Missing::<DValue>::ValidMax((-1).into())).unwrap();
+    }
+
+    #[test]
+    fn test_try_from_valid_range() {
+        let result = Missing::<f32>::try_from(&Missing::<DValue>::ValidRange(
+            DValue::from_f64(-42.0).unwrap(),
+            DValue::from_f64(42.0).unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(Missing::<f32>::ValidRange(-42.0, 42.0), result);
+    }
+
+    #[test]
+    #[should_panic(expected = "IncompatibleMissing(Number(6.805646932770577e38))")]
+    fn test_try_from_valid_range_too_large() {
+        Missing::<f32>::try_from(&Missing::<DValue>::ValidRange(
+            DValue::from_f64((f32::max_value() as f64) * 2.0).unwrap(),
+            DValue::from_f64(42.0).unwrap(),
+        ))
+        .unwrap();
+    }
+}


### PR DESCRIPTION
Adds support for specifying missing data in multiple ways:

* a single missing value
* multiple missing values
* a valid minimum
* a valid maximum
* a valid range

Currently these are mutually exclusive - exactly one must be used.

This change passes the compliance tests in
https://github.com/stackhpc/s3-active-storage-compliance-suite/pull/17.

Two new types are introduced:

* DValue is an enum that can represent any of the supported data types.
  It is based on serde_json::Number, which comes with the limitation
  that it cannot represent infinities or NaN values. Need to determine
  whether this is an issue.

* Missing<T> is an enum that represents the missing data value(s).
  When used in RequestData the type parameter T is DValue, allowing any
  dtype to be represented. When used in numeric calculations, the type
  parameter T is a primitive numeric type, i32, u64, etc.

Each supported operation (count, sum etc.) now supports missing data.
Typically there is a separate code path for this, because the filter
condition slows down the calculation significantly.