### PR TITLE
Add support for byte order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "reductionist"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ maligned = "0.2.1"
 mime = "0.3"
 ndarray = "0.15"
 ndarray-stats = "0.5"
-num-traits = "0.2.15"
+num-traits = "0.2.16"
 prometheus = { version = "0.13", features = ["process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,9 @@ regex = "1"
 serde_test = "1.0"
 
 [[bench]]
+name = "byte_order"
+harness = false
+
+[[bench]]
 name = "shuffle"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reductionist"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 # Due to AWS SDK.
 rust-version = "1.66.1"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ with a JSON payload of the form:
     // - required
     "dtype": "int32|int64|uint32|uint64|float32|float64",
 
+    // The byte order (endianness) of the data
+    // - optional, defaults to native byte order of Reductionist server
+    "byte_order": "big|little",
+
     // The offset in bytes to use when reading data
     // - optional, defaults to zero
     "offset": 0,
@@ -99,7 +103,12 @@ with a JSON payload of the form:
 
 The currently supported reducers are `max`, `min`, `sum`, `select` and `count`. All reducers return the result using the same datatype as specified in the request except for `count` which always returns the result as `int64`.
 
-The proxy adds two custom headers `x-activestorage-dtype` and `x-activestrorage-shape` to the HTTP response to allow the numeric result to be reconstructed from the binary content of the response. An additional `x-activestorage-count` header is also returned which contains the number of array elements operated on while performing the requested reduction. This header is useful, for example, to calculate the mean over multiple requests where the number of items operated on may differ between chunks.
+The proxy returns the following headers to the HTTP response:
+
+* `x-activestorage-dtype`: The data type of the data in the response payload. One of `int32`, `int64`, `uint32`, `uint64`, `float32` or `float64`.
+* `x-activestorage-byte-order`: The byte order of the data in the response payload. Either `big` or `little`.
+* `x-activestrorage-shape`: A JSON-encoded list of numbers describing the shape of the data in the response payload. May be an empty list for a scalar result.
+* `x-activestorage-count`: The number of non-missing array elements operated on while performing the requested reduction. This header is useful, for example, to calculate the mean over multiple requests where the number of items operated on may differ between chunks.
 
 [//]: <> (TODO: No OpenAPI support yet).
 [//]: <> (For a running instance of the proxy server, the full OpenAPI specification is browsable as a web page at the `{proxy-address}/redoc/` endpoint or in raw JSON form at `{proxy-address}/openapi.json`.)

--- a/benches/byte_order.rs
+++ b/benches/byte_order.rs
@@ -1,0 +1,45 @@
+/// Benchmarks for the byte order reversal implementation.
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use reductionist::array::{build_array_mut_from_shape, get_shape, reverse_array_byte_order};
+use reductionist::models::{DType, RequestData, Slice};
+use url::Url;
+
+fn get_test_request_data() -> RequestData {
+    RequestData {
+        source: Url::parse("http://example.com").unwrap(),
+        bucket: "bar".to_string(),
+        object: "baz".to_string(),
+        dtype: DType::Int32,
+        byte_order: None,
+        offset: None,
+        size: None,
+        shape: None,
+        order: None,
+        selection: None,
+        compression: None,
+        filters: None,
+        missing: None,
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    for size_k in [64, 256, 1024] {
+        let size: isize = size_k * 1024;
+        let mut data: Vec<u32> = (0_u32..(size as u32)).collect::<Vec<u32>>();
+        let mut request_data = get_test_request_data();
+        request_data.dtype = DType::Uint32;
+        let shape = get_shape(data.len(), &request_data);
+        let mut array = build_array_mut_from_shape(shape, &mut data).unwrap();
+        for selection in [None, Some(vec![Slice::new(size / 4, size / 2, 2)])] {
+            let name = format!("byte_order({}, {:?})", size, selection);
+            c.bench_function(&name, |b| {
+                b.iter(|| {
+                    reverse_array_byte_order(black_box(&mut array), &selection);
+                })
+            });
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -31,6 +31,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument("--bucket", required=True, type=str)
     parser.add_argument("--object", required=True, type=str)
     parser.add_argument("--dtype", required=True, type=str) #, choices=DTYPES) allow invalid
+    parser.add_argument("--byte-order", type=str, choices=["big", "little"])
     parser.add_argument("--offset", type=int)
     parser.add_argument("--size", type=int)
     parser.add_argument("--shape", type=str)
@@ -66,6 +67,8 @@ def build_request_data(args: argparse.Namespace) -> dict:
         'order': args.order,
         'compression': args.compression,
     }
+    if args.byte_order:
+        request_data["byte_order"] = args.byte_order
     if args.shape:
         request_data["shape"] = json.loads(args.shape)
     if args.selection:

--- a/src/array.rs
+++ b/src/array.rs
@@ -32,7 +32,7 @@ fn from_bytes<T: zerocopy::AsBytes + zerocopy::FromBytes>(
 ///
 /// * `size`: Number of elements in the array
 /// * `request_data`: RequestData object for the request
-fn get_shape(
+pub fn get_shape(
     size: usize,
     request_data: &models::RequestData,
 ) -> ndarray::Shape<Dim<ndarray::IxDynImpl>> {
@@ -71,7 +71,7 @@ fn build_array_from_shape<T>(
 ///
 /// * `shape`: The shape of the array
 /// * `data`: A slice of type `&mut [T]` containing the data to be consumed by the array view.
-fn build_array_mut_from_shape<T>(
+pub fn build_array_mut_from_shape<T>(
     shape: ndarray::Shape<Dim<ndarray::IxDynImpl>>,
     data: &mut [T],
 ) -> Result<ArrayViewMutD<T>, ActiveStorageError> {
@@ -159,7 +159,7 @@ where
 ///
 /// * `array`: An [ndarray::ArrayViewMutD] containing the data to be converted.
 /// * `selection`: Optional selection. If provided only data in this selection will be converted.
-fn reverse_array_byte_order<T>(
+pub fn reverse_array_byte_order<T>(
     array: &mut ArrayViewMutD<T>,
     selection: &Option<Vec<models::Slice>>,
 ) where

--- a/src/array.rs
+++ b/src/array.rs
@@ -216,54 +216,66 @@ mod tests {
     #[test]
     fn from_bytes_u32() {
         let value: u32 = 42;
+        let mut buf = maligned::align_first::<u8, maligned::A4>(4);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<u32>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<u32>(&mut buf).unwrap()
         );
     }
 
     #[test]
     fn from_bytes_u64() {
         let value: u64 = u64::max_value();
+        let mut buf = maligned::align_first::<u8, maligned::A8>(8);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<u64>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<u64>(&mut buf).unwrap()
         );
     }
 
     #[test]
     fn from_bytes_i32() {
         let value: i32 = -42;
+        let mut buf = maligned::align_first::<u8, maligned::A4>(4);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<i32>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<i32>(&mut buf).unwrap()
         );
     }
 
     #[test]
     fn from_bytes_i64() {
         let value: i64 = i64::min_value();
+        let mut buf = maligned::align_first::<u8, maligned::A8>(8);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<i64>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<i64>(&mut buf).unwrap()
         );
     }
 
     #[test]
     fn from_bytes_f32() {
         let value: f32 = f32::min_value();
+        let mut buf = maligned::align_first::<u8, maligned::A4>(4);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<f32>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<f32>(&mut buf).unwrap()
         );
     }
 
     #[test]
     fn from_bytes_f64() {
         let value: f64 = f64::max_value();
+        let mut buf = maligned::align_first::<u8, maligned::A8>(8);
+        buf.extend_from_slice(&value.to_ne_bytes());
         assert_eq!(
             [value],
-            from_bytes::<f64>(&mut value.to_ne_bytes()).unwrap()
+            from_bytes::<f64>(&mut buf).unwrap()
         );
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::models::*;
-use crate::types::Missing;
+use crate::types::{ByteOrder, Missing};
 
 use url::Url;
 
@@ -10,6 +10,7 @@ pub(crate) fn get_test_request_data() -> RequestData {
         bucket: "bar".to_string(),
         object: "baz".to_string(),
         dtype: DType::Int32,
+        byte_order: None,
         offset: None,
         size: None,
         shape: None,
@@ -28,6 +29,7 @@ pub(crate) fn get_test_request_data_optional() -> RequestData {
         bucket: "bar".to_string(),
         object: "baz".to_string(),
         dtype: DType::Int32,
+        byte_order: Some(ByteOrder::Little),
         offset: Some(4),
         size: Some(8),
         shape: Some(vec![2, 5]),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,8 @@
+pub mod byte_order;
 pub mod dvalue;
 pub mod missing;
 
 // Re-export types for convenience.
+pub use crate::types::byte_order::{ByteOrder, NATIVE_BYTE_ORDER, NON_NATIVE_BYTE_ORDER};
 pub use crate::types::dvalue::DValue;
 pub use crate::types::missing::Missing;

--- a/src/types/byte_order.rs
+++ b/src/types/byte_order.rs
@@ -1,0 +1,43 @@
+use serde::Deserialize;
+
+#[cfg(target_endian = "big")]
+pub const NATIVE_BYTE_ORDER: ByteOrder = ByteOrder::Big;
+
+#[cfg(target_endian = "little")]
+pub const NATIVE_BYTE_ORDER: ByteOrder = ByteOrder::Little;
+
+#[cfg(target_endian = "big")]
+pub const NON_NATIVE_BYTE_ORDER: ByteOrder = ByteOrder::Little;
+
+#[cfg(target_endian = "little")]
+pub const NON_NATIVE_BYTE_ORDER: ByteOrder = ByteOrder::Big;
+
+/// Byte order / endianness.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ByteOrder {
+    /// Big Endian
+    Big,
+    /// Little Endian
+    Little,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json;
+
+    #[test]
+    fn test_native_byte_order() {
+        assert_ne!(NATIVE_BYTE_ORDER, NON_NATIVE_BYTE_ORDER);
+    }
+
+    #[test]
+    fn test_deserialise() {
+        let little: ByteOrder = serde_json::from_str(r#""little""#).unwrap();
+        assert_eq!(ByteOrder::Little, little);
+        let big: ByteOrder = serde_json::from_str(r#""big""#).unwrap();
+        assert_eq!(ByteOrder::Big, big);
+    }
+}


### PR DESCRIPTION
Adds a new optional "byte_order" parameter to API request data that can be used to specify the byte order of the array data. It accepts values of "big" and "little".

If the byte order of the data does not match the native byte order of the server running Reductionist, the data's byte order is reversed prior to performing the operation.

A new "x-activestorage-byte-order" header is returned that describes the byte order of the response payload. This is always the native byte order of the server running Reductionist.

Also  adds a byte_order benchmark.  This can be run via:

```
cargo bench --bench byte_order
```

It benchmarks byte order reversal with multiple array sizes and both with and without a selection. This suggests that the optimisation for selections is worthwhile, when the selection covers less than roughly 2/3 of the data.

Finally, updates the version to 0.5.0 in preparation for release.