### PR TITLE
Publish to crates.io on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 jobs:
+  # Adapted from https://pratikpc.medium.com/publishing-crates-using-github-actions-165ee67780e1
   publish-crate:
     name: Publish crate to crates.io
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,26 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 jobs:
+  publish-crate:
+    name: Publish crate to crates.io
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.66.1
+          override: true
+
+      - name: Publish crate to crates.io
+        run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
   build-and-push-image:
     name: Build and publish a Docker image
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "reductionist"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reductionist"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # Due to AWS SDK.
 rust-version = "1.66.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,19 @@ version = "0.5.0"
 edition = "2021"
 # Due to AWS SDK.
 rust-version = "1.66.1"
+license = "Apache-2.0"
+description = "S3 Active Storage server"
+homepage = "https://crates.io/crates/reductionist"
+documentation = "https://docs.rs/reductionist"
+repository = "https://github.com/stackhpc/reductionist-rs"
+readme = "README.md"
+authors = ["Mark Goddard <mark@stackhpc.com>", "Scott Davidson <scott@stackhpc.com>"]
+keywords = ["s3", "ndarray"]
+# https://crates.io/category_slugs
+categories = ["mathematics", "science", "simulation"]
+
+[badges]
+maintenance = { status = "actively-developed" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Cargo.toml: add more details before publish
- CI: Add crates.io publication job on release
- Update to version 0.6.0
