### PR TITLE
Use zune-inflate library for Zlib compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "serde_test",
  "strum_macros",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,6 +1925,7 @@ dependencies = [
  "url",
  "validator",
  "zerocopy",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -2249,6 +2250,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -3069,3 +3076,12 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 zerocopy = { version = "0.6.1", features = ["alloc", "simd"] }
+zune-inflate = "0.2.54"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum_macros = "0.24"
 thiserror = "1.0"
+time = "= 0.3.23"
 tokio = { version = "1.28", features = ["full"] }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["normalize-path", "trace", "validate-request"] }


### PR DESCRIPTION
- Pin time to 0.3.23
- Use zune-inflate instead of flate2 for zlib decompression
